### PR TITLE
added support for research in compacting drawers

### DIFF
--- a/config/storagedrawers.cfg
+++ b/config/storagedrawers.cfg
@@ -99,6 +99,19 @@ registries {
     # Items should be in form domain:item or domain:item:meta. [default: [minecraft:clay, minecraft:clay_ball, 4]]
     S:compactingRules <
         minecraft:clay, minecraft:clay_ball, 4
+        contenttweaker:researchlogistics8, contenttweaker:researchlogistics1, 8
+        contenttweaker:researchlogistics64, contenttweaker:researchlogistics8, 8
+        contenttweaker:researchmechanics8, contenttweaker:researchmechanics1, 8
+        contenttweaker:researchmechanics64, contenttweaker:researchmechanics8, 8
+        contenttweaker:researchproduction8, contenttweaker:researchproduction1, 8
+        contenttweaker:researchproduction64, contenttweaker:researchproduction8, 8
+        contenttweaker:researchlogistics8, contenttweaker:researchlogistics1, 8
+        contenttweaker:researchlogistics64, contenttweaker:researchlogistics8, 8
+        contenttweaker:researchchemical8, contenttweaker:researchchemical1, 8
+        contenttweaker:researchchemical64, contenttweaker:researchchemical8, 8
+        contenttweaker:researchquantum8, contenttweaker:researchquantum1, 8
+        contenttweaker:researchquantum64, contenttweaker:researchquantum8, 8
+
      >
 
     # List of ore dictionary names to blacklist for substitution. [default: ]


### PR DESCRIPTION
this lets you put 1x, 8x, or 64x of any research into a compacting drawer, and automatically get the other kinds of research out. Much less tedious than hand-crafting them! 